### PR TITLE
Added longtoip filter

### DIFF
--- a/view/engines/hydrogen/filters/LongtoipFilter.php
+++ b/view/engines/hydrogen/filters/LongtoipFilter.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Longtoip Filter by AwesomezGuy
+ *
+ * I wanted to put a cool Copyright (C) AwesomezGuy 2011 here,
+ * but that might interfere with TomFrost accepting this into 
+ * the Hydrogen GitHub :/
+ */
+
+namespace hydrogen\view\engines\hydrogen\filters;
+
+use hydrogen\view\engines\hydrogen\Filter;
+
+class LongtoipFilter implements Filter {
+
+        public static function applyTo($string, $args, &$escape, $phpfile) {
+                return "long2ip($string)";
+        }
+}
+
+?>


### PR DESCRIPTION
Thought it was a pretty necessary filter, and when I found that it wasn't already added, I just coded it myself.

Used like so (this is an example from where I'm using it):
{{user.last_login_ip|longtoip}}
