### PR TITLE
Skipping a route

### DIFF
--- a/controller/Router.php
+++ b/controller/Router.php
@@ -524,7 +524,8 @@ class Router {
 					E_WARNING);
 			}
 			try {
-				call_user_func_array(array($inst, $function), $args ?: array());
+				$result = call_user_func_array(array($inst, $function), 
+						$args ?: array());
 			}
 			catch (NoSuchMethodException $e) {
 				if ($argProtection)
@@ -538,7 +539,7 @@ class Router {
 			}
 			if ($argProtection)
 				restore_error_handler();
-			return true;
+			return ($result || $result === NULL) ? true : false;
 		}
 		return false;
 	}


### PR DESCRIPTION
I needed this for something I've been working on. I needed to skip the function if some arguments didn't provide any results. The router would continue to search for a match and eventually stop at the matchAll rule and provide a 404 page.
